### PR TITLE
Add Travis CI

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,24 @@
+---
+
+dist: bionic
+
+language: node_js
+
+node_js:
+  - 10/*
+
+services:
+  - docker
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-5-dev
+
+install:
+  - npm i -g @elementaryos/houston
+
+script:
+  - houston ci


### PR DESCRIPTION
I just added the travis.yml file. You have to register in Travis CI too if you want to use Continuous Integration (highly recommended). See the wiki here https://github.com/elementary/houston/wiki/Continuous-Integration.

Let me know if you have any questions.

**This PR is ready for review**